### PR TITLE
plot_on_ax() fix, version increase

### DIFF
--- a/opentorsion/plots.py
+++ b/opentorsion/plots.py
@@ -173,7 +173,10 @@ class Plots:
         """
         disks = assembly.disk_elements
         shafts = assembly.shaft_elements
-        gears = assembly.gear_elements
+        if assembly.gear_elements is not None:
+            gears = assembly.gear_elements
+        else:
+            gears = []
         max_I_disk = max(disks, key=lambda disk: disk.I)
         min_I_disk = min(disks, key=lambda disk: disk.I)
         max_I_value = max_I_disk.I

--- a/opentorsion/plots.py
+++ b/opentorsion/plots.py
@@ -96,6 +96,8 @@ class Plots:
         modes : int
             Number of eigenodes to be plotted
         """
+        if self.assembly.gear_elements is not None:
+            raise NotImplementedError('Support for geared assemblies not implemented')
         lam, eigenmodes = self.assembly.eigenmodes()
         phases = np.angle(eigenmodes)
         nodes = np.arange(0, self.assembly.dofs)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="opentorsion",
-    version="0.2.4",
+    version="0.2.5",
     author="Aalto ARotor",
     author_email="arotor.software@aalto.fi",
     description="Open source library for creating torsional finite element models",


### PR DESCRIPTION
Fixed plot_on_ax() to work with assemblies that don't have gears, added an error to plot_eigenmodes() because it doesn't support assemblies with gears and increased version number