### PR TITLE
Update disk and gear element M, C, and K functions for Numpy 2.4.0+

### DIFF
--- a/opentorsion/elements/disk_element.py
+++ b/opentorsion/elements/disk_element.py
@@ -34,12 +34,12 @@ class Disk:
 
         Returns
         -------
-        M: ndarray
+        M: np.float64
             Mass matrix of the disk element
         """
 
         I = self.I
-        M = np.array([I], dtype=np.float64)
+        M = np.float64(I)
 
         return M
 
@@ -52,7 +52,7 @@ class Disk:
             Damping matrix of disk element
         """
 
-        return np.array([self.c], dtype=np.float64)
+        return np.float64(self.c)
 
     def K(self):
         """Stiffness matrix of a disk element
@@ -63,7 +63,7 @@ class Disk:
             Stiffness matrix of the disk element
         """
         k = self.k
-        K = np.array([k], dtype=np.float64)
+        K = np.float64(k)
 
         return K
 

--- a/opentorsion/elements/elastic_gear_element.py
+++ b/opentorsion/elements/elastic_gear_element.py
@@ -51,7 +51,7 @@ class ElasticGear:
         """
 
         I = self.I
-        M = np.array([[I]], dtype=np.float64)
+        M = np.float64(I)
 
         return M
 

--- a/opentorsion/elements/gear_element.py
+++ b/opentorsion/elements/gear_element.py
@@ -46,7 +46,7 @@ class Gear:
         """
 
         I = self.I
-        M = np.array([I])
+        M = np.float64(I)
 
         return M
 
@@ -59,7 +59,7 @@ class Gear:
             Stiffness matrix of the gear element
         """
 
-        K = np.zeros((1))
+        K = np.float64(0)
 
         return K
 
@@ -72,6 +72,6 @@ class Gear:
             Damping matrix of the gear element
         """
 
-        C = np.zeros((1))
+        C = np.float64(0)
 
         return C


### PR DESCRIPTION
Numpy 2.4.0 no longer allows for automatic conversion of a 1-by-1 array to scalar. Changed the return values of the M, C and K function for disk, gear and elastic gear elements from np.array(x, np.float64) to just np.float64(x), where applicable. This prevents the new ValueError when assembling with newer NumPy versions.